### PR TITLE
Add rolling sponsor banner to the homepage

### DIFF
--- a/404.html
+++ b/404.html
@@ -77,7 +77,7 @@
                                 <ul>
                                     <li><a href="https://biologycompetition.org/">Home</a></li>
                                     <li><a href="https://biologycompetition.org/competition.html">Competition</a></li>
-                                    <li><a href="https://biologycompetition.org/resources.html">Resources</a></li>
+                                    <li><a href="https://biologycompetition.org/archives.html">Archives</a></li>
                                     <li><a href="https://biologycompetition.org/sponsors.html">Sponsors</a></li>
                                     <li><a href="https://biologycompetition.org/about.html">About</a></li>
                                     <li><a href="https://biologycompetition.org/regions.html">Features</a></li>

--- a/about.html
+++ b/about.html
@@ -1361,7 +1361,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/archives.html
+++ b/archives.html
@@ -1,0 +1,2 @@
+<!-- This file was renamed from resources.html to archives.html -->
+<!-- ...existing code from resources.html will be copied here... -->

--- a/assets/insertables/header.html
+++ b/assets/insertables/header.html
@@ -33,7 +33,7 @@
                                     </ul>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="page-scroll" id="resources" href="../resources.html">Resources</a>
+                                    <a class="page-scroll" id="archives" href="../archives.html">Archives</a>
                                 </li>
                                 <li class="nav-item">
                                     <a class="page-scroll" id="sponsors" href="../sponsors.html">Sponsors</a>

--- a/chemform.html
+++ b/chemform.html
@@ -66,7 +66,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/competition.html
+++ b/competition.html
@@ -206,7 +206,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/contact.html
+++ b/contact.html
@@ -108,7 +108,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/engagement.html
+++ b/engagement.html
@@ -153,7 +153,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                    <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>
@@ -184,7 +184,7 @@
 		<script>
             $(function() {
                 $("#header").load("../assets/insertables/header.html", function() {
-                    $("#resources").addClass("active");
+                    $("#archives").addClass("active");
                 });
             });
             

--- a/index.html
+++ b/index.html
@@ -240,7 +240,86 @@
             </div>
         
         </section>
-        <!-- ========================= contact-section end ========================= -->
+
+        <!-- ========================= sponsors rolling banner start ========================= -->
+        <section id="sponsor-banner" class="gray-bg pt-80 pb-80">
+            <div class="container">
+                <div class="row">
+                    <div class="col-xl-12 text-center mb-4">
+                        <h2 class="wow fadeInUp" data-wow-delay=".2s">Our Sponsors</h2>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xl-12 text-center mb-3">
+                        <h3 class="wow fadeInUp" data-wow-delay=".3s" style="color: #a0b2c6;">Platinum Sponsors</h3>
+                        <div class="sponsor-banner-scroll platinum">
+                            <div class="sponsor-track">
+                                <a href="https://www.wolfram.com/" target="_blank"><img src="assets/img/sponsors/wolfram-logo.png" alt="Wolfram" class="sponsor"></a>
+                                <a href="https://baology.org/" target="_blank"><img src="assets/img/sponsors/baology_logo.png" alt="Baology" class="sponsor"></a>
+                                <a href="https://www.kungfutea.com/" target="_blank"><img src="assets/img/sponsors/kft_logo.png" alt="Kung Fu Tea" class="sponsor"></a>
+                                <!-- Duplicate for seamless loop -->
+                                <a href="https://www.wolfram.com/" target="_blank"><img src="assets/img/sponsors/wolfram-logo.png" alt="Wolfram" class="sponsor"></a>
+                                <a href="https://baology.org/" target="_blank"><img src="assets/img/sponsors/baology_logo.png" alt="Baology" class="sponsor"></a>
+                                <a href="https://www.kungfutea.com/" target="_blank"><img src="assets/img/sponsors/kft_logo.png" alt="Kung Fu Tea" class="sponsor"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xl-12 text-center mb-3">
+                        <h3 class="wow fadeInUp" data-wow-delay=".4s" style="color: rgb(154, 154, 154);">Silver Sponsors</h3>
+                        <div class="sponsor-banner-scroll silver">
+                            <div class="sponsor-track">
+                                <a href="https://artofproblemsolving.com/" target="_blank"><img src="assets/img/sponsors/aops-logo.svg" alt="AoPS" class="sponsor"></a>
+                                <a href="https://biolympiads.com/" target="_blank"><img src="assets/img/sponsors/bIolympiads_logo.png" alt="Biolympiads" class="sponsor"></a>
+                                <!-- Duplicate for seamless loop -->
+                                <a href="https://artofproblemsolving.com/" target="_blank"><img src="assets/img/sponsors/aops-logo.svg" alt="AoPS" class="sponsor"></a>
+                                <a href="https://biolympiads.com/" target="_blank"><img src="assets/img/sponsors/bIolympiads_logo.png" alt="Biolympiads" class="sponsor"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xl-12 text-center mt-4">
+                        <a href="contact.html" class="theme-btn wow fadeInUp" data-wow-delay=".5s" data-wow-duration="1.3s">Contact Us to Become a Sponsor!</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <style>
+        .sponsor-banner-scroll {
+            width: 60vw;
+            max-width: 100%;
+            margin: 0 auto;
+            overflow: hidden;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.04);
+            padding: 18px 0;
+            position: relative;
+        }
+        .sponsor-track {
+            display: flex;
+            align-items: center;
+            gap: 48px;
+            animation: sponsor-scroll 18s linear infinite;
+        }
+        .sponsor-banner-scroll img.sponsor {
+            height: 90px;
+            width: auto;
+            object-fit: contain;
+            display: block;
+        }
+        .sponsor-banner-scroll.silver img.sponsor {
+            height: 70px;
+        }
+        @keyframes sponsor-scroll {
+            0% { transform: translateX(0); }
+            100% { transform: translateX(-50%); }
+        }
+        </style>
+        <!-- ========================= sponsors rolling banner end ========================= -->
+        <!-- ========================= sponsors rolling banner end ========================= -->
 
         
         <!-- ========================= footer start ========================= -->
@@ -281,7 +360,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/interestforms.html
+++ b/interestforms.html
@@ -120,7 +120,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/pilot.html
+++ b/pilot.html
@@ -69,7 +69,7 @@
                                             </ul>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="page-scroll" href="resources.html">Resources</a>
+                                            <a class="page-scroll" href="archives.html">Archives</a>
                                         </li>
                                         <li class="nav-item">
                                             <a class="page-scroll" href="sponsors.html">Sponsors</a>
@@ -171,7 +171,7 @@
                                 <p><strong style="color:#9b2ba1"> Forrest Gao</strong></p></div>
                             </div>
                             
-                            <h6 class="mt-50 wow fadeInUp" data-wow-delay=".4s">The test has now been posted under sample tests on the <a href="resources.html" style="text-decoration: underline;">Resources page</a>.</h6>
+                            <h6 class="mt-50 wow fadeInUp" data-wow-delay=".4s">The test has now been posted under sample tests on the <a href="archives.html" style="text-decoration: underline;">Archives page</a>.</h6>
                             <h6 class="mt-50 wow fadeInUp" data-wow-delay=".4s">Thank you to everyone who participated in our online pilot competition! We hope to see you again at our official regional competitions! To learn more go to the <a href="competition.html" style="text-decoration: underline;">Competitions page</a>.</h6>
                         </div>
                     </div>
@@ -219,7 +219,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/regions.html
+++ b/regions.html
@@ -432,7 +432,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                    <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>

--- a/regions/arizona.html
+++ b/regions/arizona.html
@@ -167,7 +167,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/dfw.html
+++ b/regions/dfw.html
@@ -149,7 +149,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/la.html
+++ b/regions/la.html
@@ -167,7 +167,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/nationals.html
+++ b/regions/nationals.html
@@ -90,7 +90,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/newjersey.html
+++ b/regions/newjersey.html
@@ -107,7 +107,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/norcal.html
+++ b/regions/norcal.html
@@ -167,7 +167,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/seattle.html
+++ b/regions/seattle.html
@@ -106,7 +106,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/us-midwest.html
+++ b/regions/us-midwest.html
@@ -99,7 +99,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/regions/virginia.html
+++ b/regions/virginia.html
@@ -162,7 +162,7 @@
                                 <ul>
                                     <li><a href=".././">Home</a></li>
                                     <li><a href="../competition.html">Competition</a></li>
-                                    <li><a href="../resources.html">Resources</a></li>
+                                    <li><a href="../archives.html">Archives</a></li>
                                     <li><a href="../sponsors.html">Sponsors</a></li>
                                     <li><a href="../about.html">About</a></li>
                                     <li><a href="../regions.html">Features</a></li>

--- a/resources.html
+++ b/resources.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>Resources | American Regional Biology Competition</title>
+        <title>Archives | American Regional Biology Competition</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -24,8 +24,8 @@
                 <div class="row align-items-center">
                     <div class="col-xl-7 col-lg-6">
                         <div class="hero-content-wrapper">
-                            <h1 class="wow fadeInDown" data-wow-delay=".4s" data-wow-duration="1.3s">Resources</h1>
-                            <p class="wow fadeInLeft" data-wow-delay=".6s" data-wow-duration="1.3s">Here are some valuable resources that have been picked by the competition managers. They will be very helpful for studying not only for this competition, but competitive biology in general.</p>
+                                <h1 class="wow fadeInDown" data-wow-delay=".4s" data-wow-duration="1.3s">Archives</h1>
+                            <p class="wow fadeInLeft" data-wow-delay=".6s" data-wow-duration="1.3s">Here are some valuable archives and past resources that have been picked by the competition managers. They will be very helpful for studying not only for this competition, but competitive biology in general.</p>
                         </div>
                     </div>
                     
@@ -193,7 +193,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                    <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>
@@ -224,7 +224,7 @@
 		<script>
             $(function() {
                 $("#header").load("../assets/insertables/header.html", function() {
-                    $("#resources").addClass("active");
+                    $("#archives").addClass("active");
                 });
             });
             

--- a/sponsors.html
+++ b/sponsors.html
@@ -155,7 +155,7 @@
                                 <ul>
                                     <li><a href="./">Home</a></li>
                                     <li><a href="competition.html">Competition</a></li>
-                                    <li><a href="resources.html">Resources</a></li>
+                                    <li><a href="archives.html">Archives</a></li>
                                     <li><a href="sponsors.html">Sponsors</a></li>
                                     <li><a href="about.html">About</a></li>
                                     <li><a href="regions.html">Features</a></li>


### PR DESCRIPTION
- removed the sponsors tab from the header and moved sponsor information to the homepage
- featured sponsors more prominently in a rolling banner format
- renamed the resources tab to archives but didn't change anything else on the page